### PR TITLE
feat: MVP용 데이터 생성

### DIFF
--- a/src/main/java/com/example/braveCoward/model/BaseEntity.java
+++ b/src/main/java/com/example/braveCoward/model/BaseEntity.java
@@ -19,10 +19,10 @@ public abstract class BaseEntity {
     @NotNull
     @CreatedDate
     @Column(name = "created_at", columnDefinition = "TIMESTAMP", nullable = false, updatable = false)
-    private LocalDateTime createdAt;
+    private LocalDateTime createdAt = LocalDateTime.now();
 
     @NotNull
     @LastModifiedDate
     @Column(name = "updated_at", columnDefinition = "TIMESTAMP", nullable = false, updatable = true)
-    private LocalDateTime updatedAt;
+    private LocalDateTime updatedAt = LocalDateTime.now();
 }

--- a/src/main/java/com/example/braveCoward/model/Project.java
+++ b/src/main/java/com/example/braveCoward/model/Project.java
@@ -2,6 +2,7 @@ package com.example.braveCoward.model;
 
 import static lombok.AccessLevel.PROTECTED;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -15,6 +16,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -46,4 +48,19 @@ public class Project extends BaseEntity{
 
     @OneToMany(mappedBy = "project", cascade = CascadeType.ALL)
     private List<Task> tasks;
+
+    @Builder
+    public Project(
+        String title,
+        String description,
+        LocalDateTime startDate,
+        LocalDateTime endDate,
+        Team team
+    ){
+        this.title = title;
+        this.description = description;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.team = team;
+    }
 }

--- a/src/main/java/com/example/braveCoward/model/Team.java
+++ b/src/main/java/com/example/braveCoward/model/Team.java
@@ -13,6 +13,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -40,4 +41,17 @@ public class Team extends BaseEntity{
 
     @OneToMany(mappedBy = "team", cascade = CascadeType.ALL)
     private List<TeamMember> teamMembers;
+
+    @Builder
+    public Team(
+        String name,
+        String description,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+    ){
+        this.name = name;
+        this.description = description;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
 }

--- a/src/main/java/com/example/braveCoward/model/TeamMember.java
+++ b/src/main/java/com/example/braveCoward/model/TeamMember.java
@@ -11,6 +11,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -38,4 +39,17 @@ public class TeamMember extends BaseEntity{
     @ManyToOne
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
+
+    @Builder
+    public TeamMember(
+        String role,
+        String position,
+        Team team,
+        User user
+    ){
+        this.role = role;
+        this.position = position;
+        this.team = team;
+        this.user = user;
+    }
 }

--- a/src/main/java/com/example/braveCoward/model/User.java
+++ b/src/main/java/com/example/braveCoward/model/User.java
@@ -17,6 +17,7 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -46,6 +47,18 @@ public class User extends BaseEntity{
     @Column(name = "is_deleted", nullable = false)
     private Boolean isDeleted = false;
 
-    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
-    private List<TeamMember> teamMembers;
+
+    @Builder
+    public User(
+        String password,
+        String name,
+        String email,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+    ){
+        this.password = password;
+        this.name = name;
+        this.email = email;
+        this.isDeleted = false;
+    }
 }

--- a/src/main/java/com/example/braveCoward/repository/ProjectRepository.java
+++ b/src/main/java/com/example/braveCoward/repository/ProjectRepository.java
@@ -8,4 +8,6 @@ import com.example.braveCoward.model.Project;
 
 public interface ProjectRepository extends Repository<Project, Long> {
     Optional<Project> findById(Long projectId);
+
+    Project save(Project project);
 }

--- a/src/main/java/com/example/braveCoward/repository/TeamMemberRepository.java
+++ b/src/main/java/com/example/braveCoward/repository/TeamMemberRepository.java
@@ -8,4 +8,6 @@ import com.example.braveCoward.model.TeamMember;
 
 public interface TeamMemberRepository extends Repository<TeamMember, Integer> {
     Optional<TeamMember> findById(Long aLong);
+
+    TeamMember save(TeamMember teamMember);
 }

--- a/src/main/java/com/example/braveCoward/repository/TeamMemberRepository.java
+++ b/src/main/java/com/example/braveCoward/repository/TeamMemberRepository.java
@@ -4,10 +4,14 @@ import java.util.Optional;
 
 import org.springframework.data.repository.Repository;
 
+import com.example.braveCoward.model.Team;
 import com.example.braveCoward.model.TeamMember;
+import com.example.braveCoward.model.User;
 
 public interface TeamMemberRepository extends Repository<TeamMember, Integer> {
     Optional<TeamMember> findById(Long aLong);
 
     TeamMember save(TeamMember teamMember);
+
+    Optional<TeamMember> findByTeamAndUser(Team team, User user);
 }

--- a/src/main/java/com/example/braveCoward/repository/TeamRepository.java
+++ b/src/main/java/com/example/braveCoward/repository/TeamRepository.java
@@ -1,9 +1,13 @@
 package com.example.braveCoward.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.repository.Repository;
 
 import com.example.braveCoward.model.Team;
 
 public interface TeamRepository extends Repository<Team, Long> {
     Team save(Team team);
+
+    Optional<Team> findByName(String 준기팀);
 }

--- a/src/main/java/com/example/braveCoward/repository/TeamRepository.java
+++ b/src/main/java/com/example/braveCoward/repository/TeamRepository.java
@@ -1,0 +1,9 @@
+package com.example.braveCoward.repository;
+
+import org.springframework.data.repository.Repository;
+
+import com.example.braveCoward.model.Team;
+
+public interface TeamRepository extends Repository<Team, Long> {
+    Team save(Team team);
+}

--- a/src/main/java/com/example/braveCoward/repository/UserRepository.java
+++ b/src/main/java/com/example/braveCoward/repository/UserRepository.java
@@ -1,5 +1,7 @@
 package com.example.braveCoward.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.repository.Repository;
 
 import com.example.braveCoward.model.User;
@@ -7,4 +9,5 @@ import com.example.braveCoward.model.User;
 public interface UserRepository extends Repository<User, Long> {
     User save(User user);
 
+    Optional<User> findByEmail(String mail);
 }

--- a/src/main/java/com/example/braveCoward/repository/UserRepository.java
+++ b/src/main/java/com/example/braveCoward/repository/UserRepository.java
@@ -1,4 +1,10 @@
 package com.example.braveCoward.repository;
 
-public class UserRepository {
+import org.springframework.data.repository.Repository;
+
+import com.example.braveCoward.model.User;
+
+public interface UserRepository extends Repository<User, Long> {
+    User save(User user);
+
 }

--- a/src/main/java/com/example/braveCoward/service/TaskService.java
+++ b/src/main/java/com/example/braveCoward/service/TaskService.java
@@ -36,41 +36,50 @@ public class TaskService {
 
     @Transactional(readOnly = false)
     public CreateTaskResponse createTask(Long projectId, CreateTaskRequest request) {
-        User user = User.builder()
-            .password("123")
-            .name("준기")
-            .email("gjwnsrl1012@naver.com")
-            .build();
 
-        userRepository.save(user);
+        User user = userRepository.findByEmail("gjwnsrl1012@naver.com")
+            .orElseGet(() -> {
+                User newUser = User.builder()
+                    .password("123")
+                    .name("준기")
+                    .email("gjwnsrl1012@naver.com")
+                    .build();
+                return userRepository.save(newUser);
+            });
 
-        Team team = Team.builder()
-            .name("준기팀")
-            .description("허준기의 팀입니다.")
-            .createdAt(LocalDateTime.now())
-            .updatedAt(LocalDateTime.now())
-            .build();
+        Team team = teamRepository.findByName("준기팀")
+            .orElseGet(() -> {
+                Team newTeam = Team.builder()
+                    .name("준기팀")
+                    .description("허준기의 팀입니다.")
+                    .createdAt(LocalDateTime.now())
+                    .updatedAt(LocalDateTime.now())
+                    .build();
+                return teamRepository.save(newTeam);
+            });
 
-        teamRepository.save(team);
+        TeamMember teamMember = teamMemberRepository.findByTeamAndUser(team, user)
+            .orElseGet(() -> {
+                TeamMember newTeamMember = TeamMember.builder()
+                    .role("백엔드")
+                    .position("팀장")
+                    .team(team)
+                    .user(user)
+                    .build();
+                return teamMemberRepository.save(newTeamMember);
+            });
 
-        TeamMember teamMember = TeamMember.builder()
-            .role("백엔드")
-            .position("팀장")
-            .team(team)
-            .user(user)
-            .build();
-
-        teamMemberRepository.save(teamMember);
-
-        Project project = Project.builder()
-            .title("테스트 프로젝트")
-            .description("테스트입니다")
-            .startDate(LocalDateTime.now())
-            .endDate(LocalDateTime.now())
-            .team(team)
-            .build();
-
-        projectRepository.save(project);
+        Project project = projectRepository.findById(projectId)
+            .orElseGet(() -> {
+                Project newProject = Project.builder()
+                    .title("테스트 프로젝트")
+                    .description("테스트입니다")
+                    .startDate(LocalDateTime.now())
+                    .endDate(LocalDateTime.now())
+                    .team(team)
+                    .build();
+                return projectRepository.save(newProject);
+            });
 
         /*Project project = projectRepository.findById(projectId)
             .orElseThrow(() -> new IllegalArgumentException("프로젝트를 찾을 수 없습니다."));

--- a/src/main/java/com/example/braveCoward/service/TaskService.java
+++ b/src/main/java/com/example/braveCoward/service/TaskService.java
@@ -79,7 +79,7 @@ public class TaskService {
                 return teamMemberRepository.save(newTeamMember);
             });
 
-        TeamMember teamMember2 = teamMemberRepository.findByTeamAndUser(team, user)
+        TeamMember teamMember2 = teamMemberRepository.findByTeamAndUser(team, user2)
             .orElseGet(() -> {
                 TeamMember newTeamMember = TeamMember.builder()
                     .role("프론트엔드")

--- a/src/main/java/com/example/braveCoward/service/TaskService.java
+++ b/src/main/java/com/example/braveCoward/service/TaskService.java
@@ -47,6 +47,16 @@ public class TaskService {
                 return userRepository.save(newUser);
             });
 
+        User user2 = userRepository.findByEmail("gjwnsrl1012@gmail.com")
+            .orElseGet(() -> {
+                User newUser = User.builder()
+                    .password("1234")
+                    .name("준기2")
+                    .email("gjwnsrl1012@gmail.com")
+                    .build();
+                return userRepository.save(newUser);
+            });
+
         Team team = teamRepository.findByName("준기팀")
             .orElseGet(() -> {
                 Team newTeam = Team.builder()
@@ -65,6 +75,17 @@ public class TaskService {
                     .position("팀장")
                     .team(team)
                     .user(user)
+                    .build();
+                return teamMemberRepository.save(newTeamMember);
+            });
+
+        TeamMember teamMember2 = teamMemberRepository.findByTeamAndUser(team, user)
+            .orElseGet(() -> {
+                TeamMember newTeamMember = TeamMember.builder()
+                    .role("프론트엔드")
+                    .position("팀원")
+                    .team(team)
+                    .user(user2)
                     .build();
                 return teamMemberRepository.save(newTeamMember);
             });

--- a/src/main/java/com/example/braveCoward/service/TaskService.java
+++ b/src/main/java/com/example/braveCoward/service/TaskService.java
@@ -1,5 +1,6 @@
 package com.example.braveCoward.service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -11,10 +12,14 @@ import com.example.braveCoward.dto.TaskResponse;
 import com.example.braveCoward.dto.TasksResponse;
 import com.example.braveCoward.model.Project;
 import com.example.braveCoward.model.Task;
+import com.example.braveCoward.model.Team;
 import com.example.braveCoward.model.TeamMember;
+import com.example.braveCoward.model.User;
 import com.example.braveCoward.repository.ProjectRepository;
 import com.example.braveCoward.repository.TaskRepository;
 import com.example.braveCoward.repository.TeamMemberRepository;
+import com.example.braveCoward.repository.TeamRepository;
+import com.example.braveCoward.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -26,14 +31,53 @@ public class TaskService {
     private final TaskRepository taskRepository;
     private final ProjectRepository projectRepository;
     private final TeamMemberRepository teamMemberRepository;
+    private final UserRepository userRepository;
+    private final TeamRepository teamRepository;
 
+    @Transactional(readOnly = false)
     public CreateTaskResponse createTask(Long projectId, CreateTaskRequest request) {
-        Project project = projectRepository.findById(projectId)
+        User user = User.builder()
+            .password("123")
+            .name("준기")
+            .email("gjwnsrl1012@naver.com")
+            .build();
+
+        userRepository.save(user);
+
+        Team team = Team.builder()
+            .name("준기팀")
+            .description("허준기의 팀입니다.")
+            .createdAt(LocalDateTime.now())
+            .updatedAt(LocalDateTime.now())
+            .build();
+
+        teamRepository.save(team);
+
+        TeamMember teamMember = TeamMember.builder()
+            .role("백엔드")
+            .position("팀장")
+            .team(team)
+            .user(user)
+            .build();
+
+        teamMemberRepository.save(teamMember);
+
+        Project project = Project.builder()
+            .title("테스트 프로젝트")
+            .description("테스트입니다")
+            .startDate(LocalDateTime.now())
+            .endDate(LocalDateTime.now())
+            .team(team)
+            .build();
+
+        projectRepository.save(project);
+
+        /*Project project = projectRepository.findById(projectId)
             .orElseThrow(() -> new IllegalArgumentException("프로젝트를 찾을 수 없습니다."));
-
-        TeamMember teamMember = teamMemberRepository.findById(request.teamMemberId())
+*/
+        /*TeamMember teamMember = teamMemberRepository.findById(request.teamMemberId())
             .orElseThrow(() -> new IllegalArgumentException("팀 멤버를 찾을 수 없습니다."));
-
+*/
         Task task = Task.builder()
             .title(request.title())
             .description(request.description())


### PR DESCRIPTION
MVP용 데이터 생성
현재 MVP에서는 Task 추가 관련 작업만 보여주기로 했는데 이를 위해서는 User, Team, Project 관련 CRUD API가 선행되어야 하는데 그러지 못해서 일단 코드로 넣는 방식으로 짰습니다. 

근데 지금 `createTask()`라는 메서드 안에 넣어놔서 해당 요청을 날릴때마다 새로운 User, Team, Project가 생기는 상황인데 이를 해결하기 위해 어느정도 분리가 필요해 보입니다.