### PR TITLE
feat: 토큰에서 UserId 추출 기능 및 Swagger 인증 기능

### DIFF
--- a/src/main/java/com/example/braveCoward/config/SwaggerConfig.java
+++ b/src/main/java/com/example/braveCoward/config/SwaggerConfig.java
@@ -1,0 +1,52 @@
+package com.example.braveCoward.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+
+@Configuration
+public class SwaggerConfig {
+
+    private final String serverUrl;
+
+    public SwaggerConfig(
+        @Value("${swagger.server-url}") String serverUrl
+    ) {
+        this.serverUrl = serverUrl;
+    }
+
+    @Bean
+    public OpenAPI openAPI() {
+        String jwt = "Jwt Authentication";
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwt);
+        Components components = new Components().addSecuritySchemes(jwt, new SecurityScheme()
+            .name(jwt)
+            .type(SecurityScheme.Type.HTTP)
+            .scheme("Bearer")
+            .description("토큰값을 입력하여 인증을 활성화할 수 있습니다.")
+            .bearerFormat("JWT")
+        );
+        Server server = new Server();
+        server.setUrl(serverUrl);
+        return new OpenAPI()
+            .openapi("3.1.0")
+            .info(apiInfo())
+            .addSecurityItem(securityRequirement)
+            .components(components)
+            .addServersItem(server);
+    }
+
+    private Info apiInfo() {
+        return new Info()
+            .title("KOIN API")
+            .description("KOIN API 문서입니다.")
+            .version("0.0.1");
+    }
+}

--- a/src/main/java/com/example/braveCoward/config/SwaggerConfig.java
+++ b/src/main/java/com/example/braveCoward/config/SwaggerConfig.java
@@ -45,8 +45,8 @@ public class SwaggerConfig {
 
     private Info apiInfo() {
         return new Info()
-            .title("KOIN API")
-            .description("KOIN API 문서입니다.")
+            .title("BEACON API")
+            .description("BEACON API 문서입니다.")
             .version("0.0.1");
     }
 }

--- a/src/main/java/com/example/braveCoward/config/WebMVCConfig.java
+++ b/src/main/java/com/example/braveCoward/config/WebMVCConfig.java
@@ -1,8 +1,15 @@
 package com.example.braveCoward.config;
 
+import java.util.List;
+
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import com.example.braveCoward.global.ExtractAuthenticationInterceptor;
+import com.example.braveCoward.global.UserIdArgumentResolver;
 
 import lombok.RequiredArgsConstructor;
 
@@ -10,11 +17,25 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class WebMVCConfig implements WebMvcConfigurer {
 
+    private final ExtractAuthenticationInterceptor extractAuthenticationInterceptor;
+    private final UserIdArgumentResolver userIdArgumentResolver;
+
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
             .allowedOriginPatterns("*")
             .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
             .allowCredentials(true);
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(extractAuthenticationInterceptor)
+            .addPathPatterns("/**");
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(userIdArgumentResolver);
     }
 }

--- a/src/main/java/com/example/braveCoward/config/WebMVCConfig.java
+++ b/src/main/java/com/example/braveCoward/config/WebMVCConfig.java
@@ -31,7 +31,16 @@ public class WebMVCConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(extractAuthenticationInterceptor)
-            .addPathPatterns("/**");
+            .addPathPatterns("/**")
+            .excludePathPatterns(
+                "/swagger-ui/**",      // Swagger UI 경로
+                "/v3/api-docs/**",     // OpenAPI 문서 경로
+                "/swagger-resources/**",
+                "/webjars/**",
+                "/swagger-ui.html",
+                "/user/login",
+                "/error"
+            );
     }
 
     @Override

--- a/src/main/java/com/example/braveCoward/controller/ProjectController.java
+++ b/src/main/java/com/example/braveCoward/controller/ProjectController.java
@@ -2,13 +2,16 @@ package com.example.braveCoward.controller;
 
 import com.example.braveCoward.dto.project.ProjectCreateRequest;
 import com.example.braveCoward.dto.project.ProjectCreateResponse;
+import com.example.braveCoward.global.UserId;
 import com.example.braveCoward.service.ProjectService;
+import com.example.braveCoward.swagger.ProjectApi;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/teams/{teamId}/projects")
-public class ProjectController {
+public class ProjectController implements ProjectApi {
 
     private final ProjectService projectService;
 
@@ -18,8 +21,10 @@ public class ProjectController {
 
     @PostMapping
     public ResponseEntity<ProjectCreateResponse> createProject(
-            @PathVariable Long teamId,
-            @RequestBody ProjectCreateRequest request) {
+        @PathVariable Long teamId,
+        @RequestBody ProjectCreateRequest request,
+        @UserId Integer userId
+    ) {
         ProjectCreateResponse response = projectService.createProject(teamId, request);
         return ResponseEntity.status(201).body(response);
     }

--- a/src/main/java/com/example/braveCoward/global/AuthContext.java
+++ b/src/main/java/com/example/braveCoward/global/AuthContext.java
@@ -1,0 +1,26 @@
+package com.example.braveCoward.global;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.annotation.RequestScope;
+
+@Component
+@RequestScope
+public class AuthContext {
+
+    private Integer userId;
+
+    public Integer getUserId() {
+        if (userId == null) {
+            throw new IllegalArgumentException("Access token is required or invalid.");
+        }
+        return userId;
+    }
+
+    public boolean isAnonymous() {
+        return userId == null;
+    }
+
+    public void setUserId(Integer userId) {
+        this.userId = userId;
+    }
+}

--- a/src/main/java/com/example/braveCoward/global/ExtractAuthenticationInterceptor.java
+++ b/src/main/java/com/example/braveCoward/global/ExtractAuthenticationInterceptor.java
@@ -1,0 +1,50 @@
+package com.example.braveCoward.global;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ExtractAuthenticationInterceptor implements HandlerInterceptor {
+
+    private static final String BEARER_TYPE = "Bearer ";
+    private static final int BEARER_TYPE_LEN = 7;
+
+    private final JwtProvider jwtProvider;
+    private final AuthContext authContext;
+    private final UserIdContext userIdContext;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        String token = extractAccessToken(request);
+        if (token == null) {
+            throw new IllegalArgumentException("Access token is required.");
+        }
+
+        Integer userId = jwtProvider.getUserId(token);
+        if (userId == null) {
+            throw new IllegalArgumentException("Invalid token or userId.");
+        }
+
+        authContext.setUserId(userId);
+        userIdContext.setUserId(userId);
+
+        return true;
+    }
+
+    public static String extractAccessToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (bearerToken == null) {
+            return null;
+        }
+        if (!bearerToken.startsWith(BEARER_TYPE)) {
+            return null;
+        }
+        return bearerToken.substring(BEARER_TYPE_LEN);
+    }
+
+}

--- a/src/main/java/com/example/braveCoward/global/JwtProvider.java
+++ b/src/main/java/com/example/braveCoward/global/JwtProvider.java
@@ -1,4 +1,4 @@
-package com.example.braveCoward.auth;
+package com.example.braveCoward.global;
 
 import java.security.Key;
 import java.sql.Date;
@@ -9,7 +9,7 @@ import java.util.Base64;
 
 import javax.crypto.SecretKey;
 
-import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Value;
@@ -51,15 +51,20 @@ public class JwtProvider {
         return LocalDateTime.ofInstant(Instant.now().plusMillis(expirationTime), ZoneId.systemDefault());
     }
 
-    public Long getUserIdFromToken(String token) {
-        Claims claims = Jwts.parser()
-                .setSigningKey(getSecretKey())
+    public Integer getUserId(String token) {
+        try {
+            String userId = Jwts.parser()
+                .verifyWith(getSecretKey())
                 .build()
-                .parseClaimsJws(token)
-                .getBody();
-        return claims.get("id", Long.class);
+                .parseSignedClaims(token)
+                .getPayload()
+                .get("id")
+                .toString();
+            return Integer.parseInt(userId);
+        } catch (JwtException e) {
+            throw new IllegalArgumentException("Invalid token: " + token, e);
+        }
     }
-
 
     private SecretKey getSecretKey() {
         String encoded = Base64.getEncoder().encodeToString(secretKey.getBytes());

--- a/src/main/java/com/example/braveCoward/global/UserId.java
+++ b/src/main/java/com/example/braveCoward/global/UserId.java
@@ -1,0 +1,16 @@
+package com.example.braveCoward.global;
+
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import io.swagger.v3.oas.annotations.Hidden;
+
+@Hidden
+@Target(PARAMETER)
+@Retention(RUNTIME)
+public @interface UserId {
+
+}

--- a/src/main/java/com/example/braveCoward/global/UserIdArgumentResolver.java
+++ b/src/main/java/com/example/braveCoward/global/UserIdArgumentResolver.java
@@ -1,0 +1,29 @@
+package com.example.braveCoward.global;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class UserIdArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final UserIdContext userIdContext;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(UserId.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+        NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+
+        return userIdContext.getUserId();
+    }
+}

--- a/src/main/java/com/example/braveCoward/global/UserIdContext.java
+++ b/src/main/java/com/example/braveCoward/global/UserIdContext.java
@@ -1,0 +1,21 @@
+package com.example.braveCoward.global;
+
+import java.util.Objects;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.annotation.RequestScope;
+
+@Component
+@RequestScope
+public class UserIdContext {
+
+    private Integer userId;
+
+    public Integer getUserId() {
+        return userId;
+    }
+
+    public void setUserId(Integer userId) {
+        this.userId = userId;
+    }
+}

--- a/src/main/java/com/example/braveCoward/model/User.java
+++ b/src/main/java/com/example/braveCoward/model/User.java
@@ -66,5 +66,4 @@ public class User extends BaseEntity{
     public boolean isSamePassword(PasswordEncoder passwordEncoder, String password) {
         return passwordEncoder.matches(password, this.password);
     }
-
 }

--- a/src/main/java/com/example/braveCoward/service/UserService.java
+++ b/src/main/java/com/example/braveCoward/service/UserService.java
@@ -7,7 +7,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.example.braveCoward.auth.JwtProvider;
+import com.example.braveCoward.global.JwtProvider;
 import com.example.braveCoward.dto.MembersResponse;
 import com.example.braveCoward.dto.UserLoginRequest;
 import com.example.braveCoward.dto.UserLoginResponse;

--- a/src/main/java/com/example/braveCoward/swagger/DoApi.java
+++ b/src/main/java/com/example/braveCoward/swagger/DoApi.java
@@ -4,7 +4,6 @@ import com.example.braveCoward.dto.Do.CreateDoRequest;
 import com.example.braveCoward.dto.Do.CreateDoResponse;
 import com.example.braveCoward.dto.Do.DoResponse;
 import com.example.braveCoward.dto.Do.DosResponse;
-import com.example.braveCoward.dto.project.ProjectRequest;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;

--- a/src/main/java/com/example/braveCoward/swagger/ProjectApi.java
+++ b/src/main/java/com/example/braveCoward/swagger/ProjectApi.java
@@ -2,28 +2,33 @@ package com.example.braveCoward.swagger;
 
 import com.example.braveCoward.dto.project.ProjectCreateRequest;
 import com.example.braveCoward.dto.project.ProjectCreateResponse;
+import com.example.braveCoward.global.UserId;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
 
-@RequestMapping(value = "/teams/{teamId}/projects")
 @Tag(name = "(Normal) Project", description = "Project 생성 API")
 public interface ProjectApi {
 
     @Operation(summary = "프로젝트 생성", description = "새로운 프로젝트를 생성합니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "201", description = "프로젝트 생성 성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
-            @ApiResponse(responseCode = "404", description = "팀을 찾을 수 없음")
+        @ApiResponse(responseCode = "201", description = "프로젝트 생성 성공"),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+        @ApiResponse(responseCode = "404", description = "팀을 찾을 수 없음")
     })
-    @PostMapping
+    @SecurityRequirement(name = "Jwt Authentication")
+    @PostMapping("/teams/{teamId}/projects")
     ResponseEntity<ProjectCreateResponse> createProject(
-            @PathVariable Long teamId,
-            @RequestBody ProjectCreateRequest request);
+        @PathVariable Long teamId,
+        @RequestBody ProjectCreateRequest request,
+        @UserId Integer userId
+    );
 }


### PR DESCRIPTION
## 작업 내용 

---

인증 및 API 사용성을 개선하기 위해 @UserId 애노테이션 추가, JWT 기반 인증 로직 구현, 그리고 Swagger UI 개선을 진행하였습니다.

---

1. @UserId 애노테이션 추가
* @UserId는 컨트롤러 메서드 파라미터에 사용되는 커스텀 애노테이션으로, 요청의 JWT 토큰에서 userId를 추출하여 자동으로 주입됩니다.
* 이를 통해 컨트롤러에서 인증된 사용자 ID를 간단하게 활용할 수 있습니다.
* 예시:
```java
@PostMapping
public ResponseEntity<?> createProject(
    @PathVariable Long teamId,
    @RequestBody ProjectCreateRequest request,
    @UserId Integer userId
) {
    // userId는 JWT에서 추출된 사용자 ID
    return ResponseEntity.ok("User ID: " + userId);
}
```
---
2. JWT 기반 인증 로직 구현
* ExtractAuthenticationInterceptor를 구현하여 모든 요청의 Authorization 헤더에서 JWT 토큰을 추출하고, 이를 파싱하여 userId를 설정하도록 처리하였습니다.
* 추출된 userId는 AuthContext와 UserIdContext에 저장되며, 이후 컨트롤러 메서드에서 @UserId 애노테이션을 통해 사용할 수 있습니다.
* JWT 검증 실패, 토큰 누락, 또는 유효하지 않은 토큰인 경우 예외를 발생시켜 요청을 차단합니다.
---
3. Swagger UI 개선
* Swagger UI에 JWT 인증을 위한 Authorize 버튼을 추가하여, API 요청 시 Bearer 인증을 간편하게 테스트할 수 있도록 개선하였습니다.
* Swagger 설정에 Bearer 인증 스키마를 정의하여, 인증된 상태에서 모든 API 요청에 Authorization: Bearer <JWT> 헤더가 자동으로 포함되도록 설정했습니다.
* Swagger UI 사용 방법:
![image](https://github.com/user-attachments/assets/facd946b-3c92-499b-bd5c-1bfb79f358db)
![image](https://github.com/user-attachments/assets/f5908a8f-78cf-4135-a02e-b6f203a0b1e0)

1. Swagger UI의 상단 Authorize 버튼 클릭.
2. 발급받은 JWT 토큰을 입력 (예: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzM4NCJ9...).
3. login을 제외한 다른 api들은 인증된 상태에서 API 호출 가능.