### PR TITLE
refactor: Plan QA 수정사항 

### DIFF
--- a/src/main/java/com/example/braveCoward/controller/PlanController.java
+++ b/src/main/java/com/example/braveCoward/controller/PlanController.java
@@ -79,8 +79,8 @@ public class PlanController implements PlanApi {
     @GetMapping("/search")
     public ResponseEntity<Page<PlanResponse>> searchPlan(
         @RequestParam String keyword,
-        PlanSearchFilter filter,
-        PageDTO pageDTO
+        @RequestParam PlanSearchFilter filter,
+        @Valid PageDTO pageDTO
     ) {
         Page<PlanResponse> responses = planService.searchPlan(keyword, filter, pageDTO);
         return ResponseEntity.ok(responses);

--- a/src/main/java/com/example/braveCoward/dto/PageDTO.java
+++ b/src/main/java/com/example/braveCoward/dto/PageDTO.java
@@ -1,13 +1,16 @@
 package com.example.braveCoward.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
 
 public record PageDTO(
 
-    @Schema(description = "페이지 번호 (0부터 시작)", example = "1")
+    @Schema(description = "페이지 번호 (1부터 시작)", example = "1")
+    @Min(value = 1, message = "페이지 번호는 1 이상이어야 합니다.")
     int page,
 
     @Schema(description = "페이지에 들어있는 데이터 수", example = "10")
+    @Min(value = 1, message = "페이지 크기는 1 이상이어야 합니다.")
     int pageSize
 ) {
 }

--- a/src/main/java/com/example/braveCoward/dto/plan/CreatePlanRequest.java
+++ b/src/main/java/com/example/braveCoward/dto/plan/CreatePlanRequest.java
@@ -2,8 +2,6 @@ package com.example.braveCoward.dto.plan;
 
 import java.time.LocalDate;
 
-import org.springframework.cglib.core.Local;
-
 import com.example.braveCoward.model.Plan;
 import com.fasterxml.jackson.annotation.JsonFormat;
 
@@ -12,8 +10,7 @@ public record CreatePlanRequest(
     String description,
     LocalDate startDate,
     LocalDate endDate,
-    @JsonFormat(shape = JsonFormat.Shape.STRING)Plan.Status status,
-    Long projectId,
+    @JsonFormat(shape = JsonFormat.Shape.STRING) Plan.Status status,
     Long teamMemberId
 ) {
 

--- a/src/main/java/com/example/braveCoward/model/Plan.java
+++ b/src/main/java/com/example/braveCoward/model/Plan.java
@@ -60,8 +60,8 @@ public class Plan extends BaseEntity {
     private List<Do> dos = new ArrayList<>();
 
     public enum Status {
-        NOT_STARTED("not started"),
-        IN_PROGRESS("in progress"),
+        NOT_STARTED("not_started"),
+        IN_PROGRESS("in_progress"),
         COMPLETED("completed");
 
         private final String jsonValue;

--- a/src/main/java/com/example/braveCoward/service/PlanService.java
+++ b/src/main/java/com/example/braveCoward/service/PlanService.java
@@ -34,7 +34,7 @@ public class PlanService {
     private final TeamMemberRepository teamMemberRepository;
     private final DoRepository doRepository;
 
-    @Transactional(readOnly = false)
+    @Transactional
     public CreatePlanResponse createPlan(Long projectId, CreatePlanRequest request) {
         Project project = projectRepository.findById(projectId)
             .orElseThrow(() -> new IllegalArgumentException("프로젝트를 찾을 수 없습니다."));
@@ -57,10 +57,10 @@ public class PlanService {
         return CreatePlanResponse.from(savedPlan);
     }
 
-    @Transactional(readOnly = false)
+    @Transactional
     public void deletePlan(Long planId) {
         Plan plan = planRepository.findById(planId)
-            .orElseThrow(() -> new IllegalArgumentException("Plan not found with id: " + planId));
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 Plan입니다.: " + planId));
 
         doRepository.deleteByPlanId(planId);
 
@@ -75,6 +75,9 @@ public class PlanService {
     }
 
     public Page<PlanResponse> getPlansByProjectId(Long projectId, PageDTO pageDTO) {
+        Project project = projectRepository.findById(projectId)
+            .orElseThrow(() -> new IllegalArgumentException("프로젝트를 찾을 수 없습니다."));
+
         Pageable pageable = PageRequest.of(pageDTO.page(), pageDTO.pageSize(),
             Sort.by(Sort.Direction.DESC, "id"));
         Page<Plan> plans = planRepository.findAllByProjectId(projectId, pageable);
@@ -82,7 +85,7 @@ public class PlanService {
         return plans.map(PlanResponse::from);
     }
 
-    @Transactional(readOnly = false)
+    @Transactional
     public void changePlanStatus(Long planId, Plan.Status status) {
         Plan plan = planRepository.findById(planId)
             .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 Plan입니다"));

--- a/src/main/java/com/example/braveCoward/service/PlanService.java
+++ b/src/main/java/com/example/braveCoward/service/PlanService.java
@@ -1,7 +1,5 @@
 package com.example.braveCoward.service;
 
-import java.util.List;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -93,9 +91,8 @@ public class PlanService {
         plan.setStatus(status);
     }
 
-    @Transactional
     public Page<PlanResponse> searchPlan(String keyword, PlanSearchFilter filter, PageDTO pageDTO) {
-        Pageable pageable = PageRequest.of(pageDTO.page(), pageDTO.pageSize(),
+        Pageable pageable = PageRequest.of(pageDTO.page() - 1, pageDTO.pageSize(),
             Sort.by(Sort.Direction.DESC, "id"));
 
         Page<Plan> searchedPlans = switch (filter) {


### PR DESCRIPTION
### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #90 

## ⛏ 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
- [x]  없는 프로젝트 아이디에 대한 plan을 불러올때 예외 처리 필요
    - [x]  없는 plan에 대한 예외 처리도!
    - [x]  삭제도~
- [x]  plan 단일 조회할 때 관련된 do 도 같이 반환 필요 → `do` 목록 조회 api가 있긴함!
- [x]  plan 추가할때 status 형식 설명 or `_` 도 인식하도록 수정 필요
    - [x]  api 별로 입력값이 달라서 통일해야할  → `_` 포함으로 통일 완료
- [x]  plan생성 이미 uri에서 projectId를 받아오는데 requestBody에서 projectId를 또 입력해야할 필요가 있나?
projectId, teamMemberId
- [x]  검색할 때 page 0부터 시작하는거 코드에 +1 처리해서 1부터 시작하게 하면 될 듯

## 📌 PR Point
<!-- 주의할 사항이나 같이 고민해볼 부분, 리뷰를 원하는 부분 등을 적어주세요! -->
- 내용
