### PR TITLE
feat: 하루마다 새로운 log 파일 생기게 설정

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -6,14 +6,20 @@
         </encoder>
     </appender>
 
-    <!-- 로그 파일 저장 -->
+    <!-- 로그 파일 저장 (한 시간마다 새로운 파일 생성) -->
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>logs/application.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <!-- 하루 단위로 로그 파일을 분리 -->
-            <fileNamePattern>logs/application-%d{yyyy-MM-dd}.log</fileNamePattern>
-            <maxHistory>7</maxHistory> <!-- 7일간의 로그 파일 유지 -->
+            <!-- 파일 이름을 시간 단위로 변경 -->
+            <fileNamePattern>logs/application-%d{yyyy-MM-dd_HH}.log</fileNamePattern>
+
+            <!-- 로그 파일을 최대 7일간 유지 -->
+            <maxHistory>7</maxHistory>
+
+            <!-- 전체 로그 파일 크기 제한 -->
             <totalSizeCap>10MB</totalSizeCap>
+
+            <!-- 1MB 초과 시 새로운 파일 생성 -->
+            <maxFileSize>1MB</maxFileSize>
         </rollingPolicy>
         <encoder>
             <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n</pattern>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -6,11 +6,11 @@
         </encoder>
     </appender>
 
-    <!-- 로그 파일 저장 (한 시간마다 새로운 파일 생성) -->
+    <!-- 로그 파일 저장 -->
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <!-- 파일 이름을 시간 단위로 변경 -->
-            <fileNamePattern>logs/application-%d{yyyy-MM-dd_HH}.log</fileNamePattern>
+            <!-- 하루 단위로 로그 파일을 분리 -->
+            <fileNamePattern>logs/application-%d{yyyy-MM-dd}.log</fileNamePattern>
 
             <!-- 로그 파일을 최대 7일간 유지 -->
             <maxHistory>7</maxHistory>


### PR DESCRIPTION
### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #71 

## ⛏ 작업 내용
- [x] `fileNamePattern`을 logs/application-%d{yyyy-MM-dd_HH-mm-ss}.log로 변경하여 로그 발생 시마다 로그가 축적됨
- [x] 한 시간마다 새로운 로그 파일이 생성되게 설정함
- [x] maxHistory=7 설정을 유지하면 일주일이 지난 파일은 자동 삭제됨
- [x] totalSizeCap = 10MB 설정을 통해 전체 로그 파일 크기를 10MB로 제한함
- [x] maxFileSize = 1MB로 제한해 파일 하나당 최대 크기를 1MB로 설정 (이를 넘어갈 시, 새로운 파일 생성)
- [x] "com.example" 패키지의 로그만 DEBUG 레벨부터 기록
→ 즉, "com.example"에서 발생한 로그는 DEBUG, INFO, WARN, ERROR 모두 출력
→ "com.example" 외의 패키지는 INFO 이상만 출력됨

## 📌 PR Point
<!-- 주의할 사항이나 같이 고민해볼 부분, 리뷰를 원하는 부분 등을 적어주세요! -->
- 혹시 더 추가로 관리해야할 부분이 있는지 궁금합니다. 실제로 에러를 발생시켜 로그를 활용해보면 좋을 것 같습니다.

> "com.example" 패키지의 로그만 DEBUG 레벨부터 기록
→ 즉, "com.example"에서 발생한 로그는 DEBUG, INFO, WARN, ERROR 모두 출력
→ "com.example" 외의 패키지는 INFO 이상만 출력됨

- "com.example" 패키지의 로그를 DEBUG부터 기록하는 걸로 설정했는데, INFO부터 하는 걸로 변경할지도 고민됩니다..!
