### PR TITLE
ref : swagger 알람테스트 바로 실행

### DIFF
--- a/src/main/java/com/example/braveCoward/controller/AlarmController.java
+++ b/src/main/java/com/example/braveCoward/controller/AlarmController.java
@@ -23,3 +23,4 @@ public class AlarmController {
         return "스케줄링된 이메일이 즉시 실행되었습니다.";
     }
 }
+

--- a/src/main/java/com/example/braveCoward/controller/AlarmController.java
+++ b/src/main/java/com/example/braveCoward/controller/AlarmController.java
@@ -3,6 +3,7 @@ package com.example.braveCoward.controller;
 import com.example.braveCoward.model.User;
 import com.example.braveCoward.repository.UserRepository;
 import com.example.braveCoward.service.AlarmService;
+import com.example.braveCoward.service.PlanNotificationScheduler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -14,13 +15,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class AlarmController {
     private final AlarmService alarmService;
-    private final UserRepository userRepository;
+    private final PlanNotificationScheduler planNotificationScheduler;
 
-    @GetMapping("/send-email")
-    public String sendEmailToUser(@RequestParam Long userId, @RequestParam String description) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 ID의 사용자가 없습니다."));
-
-        return alarmService.sendEmailToUser(user, description);
+    @GetMapping("/send-test-email")
+    public String sendScheduledEmailNow() {
+        planNotificationScheduler.sendPlanNotifications();
+        return "스케줄링된 이메일이 즉시 실행되었습니다.";
     }
 }


### PR DESCRIPTION
### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #94

## ⛏ 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
- 알람 QA수정 정해진 서버 스케쥴링 시간 외에도 테스트 할 때 바로 전송 확인 기능 추가

## 📌 PR Point
<!-- 주의할 사항이나 같이 고민해볼 부분, 리뷰를 원하는 부분 등을 적어주세요! -->
- 현재 알림 서비스는 매일 한 번 정해진 시간에 알림 조건에 해당하는 plan에 대한 이메일이 전송됩니다
- 테스트를 할 때 바로 전송을 확인하고 싶은데 스케쥴링의 전송 시간을 계속 테스트에 맞게 변경하기 번거로워서 swagger상에서 실행을 하면 테스트 시점으로 알림이 전송되도록 했습니다 - 개발 편의성을 위함
